### PR TITLE
Count service bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GET /v1/service_brokers/p-redis/service_bindings
 #### cURL
 
 ```shell
-$ curl "https://[your-sbire-host]/v1/service_brokers/p-redis/service_bindings" -X GET -u user:changeit
+$ curl "https://[your-sbire-host]/v1/service_brokers/p-redis/service_bindings?org_name=org2&space_name=space12" -X GET -u user:changeit
 ```
 
 ### Response
@@ -39,61 +39,33 @@ $ curl "https://[your-sbire-host]/v1/service_brokers/p-redis/service_bindings" -
 ```
 #### Body
 ```shell
-[
-
 {
-
-    "id": "6b9b2c7f-3aa9-4699-8535-80268b861c03",
-    "serviceInstanceId": "bc07a4a3-2ec6-47ef-8973-d79a56884b6d",
-    "serviceInstanceName": "my-redis-111",
-    "applicationId": "b1524276-9a5c-4d9a-9467-0f6e7aa2981e",
-    "applicationName": "app111",
-    "servicePlan": "shared-vm",
-    "service": "p-redis",
-    "space": "space11",
-    "organization": "org1"
-
-},
-{
-
-    "id": "69a822a7-55cf-4d94-9994-b93d3d9e08ef",
-    "serviceInstanceId": "8856f1b6-091c-4d24-b9be-40df853e6be8",
-    "serviceInstanceName": "my-redis-211",
-    "applicationId": "139ca9b0-ad9b-437f-8db2-3ca2cb1f8566",
-    "applicationName": "app211",
-    "servicePlan": "dedicated-vm",
-    "service": "p-redis",
-    "space": "space11",
-    "organization": "org1"
-
-},
-{
-
-    "id": "eef72ea9-b01a-4b6d-b328-30a6e92eddd3",
-    "serviceInstanceId": "ce6bde82-c77a-4e1d-b04b-dd39d17e5cf8",
-    "serviceInstanceName": "my-redis-112",
-    "applicationId": "2f4bf8e3-968f-4350-8c01-39e0ea31a4e5",
-    "applicationName": "app112",
-    "servicePlan": "shared-vm",
-    "service": "p-redis",
-    "space": "space12",
-    "organization": "org2"
-
-},
-{
-
-    "id": "eef72ea9-b01a-4b6d-b328-30a6e92eddd3",
-    "serviceInstanceId": "6f184a79-28bd-435d-9b01-65e2be8e16d7",
-    "serviceInstanceName": "my-redis-122",
-    "applicationId": "d7609d5c-5ec0-40e8-a15b-24d83ea3ff28"
-    "applicationName": "app122",
-    "servicePlan": "shared-vm",
-    "service": "p-redis",
-    "space": "space22",
-    "organization": "org2"
-
+    "total_results": 1
+    "total_pages": 1,
+    "next_url": null,
+    "prev_url": null,
+    "resources": [
+      {
+        "entity": {
+            "id": "6b9b2c7f-3aa9-4699-8535-80268b861c03",
+            "serviceInstanceId": "ce6bde82-c77a-4e1d-b04b-dd39d17e5cf8",
+            "serviceInstanceName": "my-redis-112",
+            "applicationId": "2f4bf8e3-968f-4350-8c01-39e0ea31a4e5",
+            "applicationName": "app112",
+            "servicePlan": "shared-vm",
+            "service": "p-redis",
+            "space": "space12",
+            "organization": "org2"
+        },
+        "metadata": {
+            "guid": "6b9b2c7f-3aa9-4699-8535-80268b861c03",
+            "created_at": "2017-01-13T20:22:35Z",
+            "updated_at": null,
+            "url": "/v2/service_bindings/6b9b2c7f-3aa9-4699-8535-80268b861c03"
+        }
+      }
+    ]
 }
-]
 ```
 
 ## Rebind service bindings for service broker
@@ -118,10 +90,11 @@ POST /v1/service_brokers/p-redis/service_bindings
 | plan_name | service plan name | plan_name=shared-vm | |
 | instance_name | service instance name | instance_name=my-redis-111 | |
 
+
 #### cURL
 
 ```shell
-$ curl "https://[your-sbire-host]/v1/service_brokers/p-redis/service_bindings" -X POST -u user:changeit
+$ curl "https://[your-sbire-host]/v1/service_brokers/p-redis/service_bindings?org_name=org2&space_name=space12" -X POST -u user:changeit
 ```
 
 ### Response
@@ -131,59 +104,31 @@ $ curl "https://[your-sbire-host]/v1/service_brokers/p-redis/service_bindings" -
 ```
 #### Body
 ```shell
-[
-
 {
-
-    "id": "8d4b7ad0-00b6-4bab-b76a-c1cbc7388c95",
-    "serviceInstanceId": "bc07a4a3-2ec6-47ef-8973-d79a56884b6d",
-    "serviceInstanceName": "my-redis-111",
-    "applicationId": "b1524276-9a5c-4d9a-9467-0f6e7aa2981e",
-    "applicationName": "app111",
-    "servicePlan": "shared-vm",
-    "service": "p-redis",
-    "space": "space11",
-    "organization": "org1"
-
-},
-{
-
-    "id": "12672d87-317b-492a-84e5-dd299653d5f6",
-    "serviceInstanceId": "8856f1b6-091c-4d24-b9be-40df853e6be8",
-    "serviceInstanceName": "my-redis-211",
-    "applicationId": "139ca9b0-ad9b-437f-8db2-3ca2cb1f8566",
-    "applicationName": "app211",
-    "servicePlan": "dedicated-vm",
-    "service": "p-redis",
-    "space": "space11",
-    "organization": "org1"
-
-},
-{
-
-    "id": "86dfb2e1-dd9d-435b-a22a-594a3c488c94",
-    "serviceInstanceId": "ce6bde82-c77a-4e1d-b04b-dd39d17e5cf8",
-    "serviceInstanceName": "my-redis-112",
-    "applicationId": "2f4bf8e3-968f-4350-8c01-39e0ea31a4e5",
-    "applicationName": "app112",
-    "servicePlan": "shared-vm",
-    "service": "p-redis",
-    "space": "space12",
-    "organization": "org2"
-
-},
-{
-
-    "id": "932faf5a-fe25-4158-b6b6-32d16cecb7a1",
-    "serviceInstanceId": "6f184a79-28bd-435d-9b01-65e2be8e16d7",
-    "serviceInstanceName": "my-redis-122",
-    "applicationId": "d7609d5c-5ec0-40e8-a15b-24d83ea3ff28"
-    "applicationName": "app122",
-    "servicePlan": "shared-vm",
-    "service": "p-redis",
-    "space": "space22",
-    "organization": "org2"
-
+    "total_results": 1
+    "total_pages": 1,
+    "next_url": null,
+    "prev_url": null,
+    "resources": [
+      {
+        "entity": {
+            "id": "68d4b7ad0-00b6-4bab-b76a-c1cbc7388c95",
+            "serviceInstanceId": "ce6bde82-c77a-4e1d-b04b-dd39d17e5cf8",
+            "serviceInstanceName": "my-redis-112",
+            "applicationId": "2f4bf8e3-968f-4350-8c01-39e0ea31a4e5",
+            "applicationName": "app112",
+            "servicePlan": "shared-vm",
+            "service": "p-redis",
+            "space": "space12",
+            "organization": "org2"
+        },
+        "metadata": {
+            "guid": "8d4b7ad0-00b6-4bab-b76a-c1cbc7388c95",
+            "created_at": "2017-01-13T20:22:35Z",
+            "updated_at": null,
+            "url": "/v2/service_bindings/8d4b7ad0-00b6-4bab-b76a-c1cbc7388c95"
+        }
+      }
+    ]
 }
-]
 ```

--- a/src/main/java/com/orange/ops/sbire/controller/ServiceBindingsController.java
+++ b/src/main/java/com/orange/ops/sbire/controller/ServiceBindingsController.java
@@ -1,19 +1,17 @@
 package com.orange.ops.sbire.controller;
 
-import com.orange.ops.sbire.domain.ImmutableListServiceBindingsRequest;
-import com.orange.ops.sbire.domain.ImmutableRebindServiceBindingsRequest;
-import com.orange.ops.sbire.domain.ServiceBindingDetail;
-import com.orange.ops.sbire.domain.ServiceBindingsService;
+import com.orange.ops.sbire.domain.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 
 /**
+ * @see <a href="https://github.com/orange-cloudfoundry/sbire">API spec</a>
+ *
  * @author Sebastien Bortolussi
  */
 @RestController
@@ -43,12 +41,12 @@ public class ServiceBindingsController {
      * <p>
      **/
     @GetMapping(value = "/v1/service_brokers/{brokerName}/service_bindings")
-    public List<ServiceBindingDetail> listServiceBindings(@PathVariable("brokerName") String brokerName,
-                                                          @RequestParam("org_name") Optional<String> orgName,
-                                                          @RequestParam("space_name") Optional<String> spaceName,
-                                                          @RequestParam("service_label") Optional<String> serviceLabel,
-                                                          @RequestParam("plan_name") Optional<String> planName,
-                                                          @RequestParam("instance_name") Optional<String> instanceName) {
+    public ListServiceBindingsResponse listServiceBindings(@PathVariable("brokerName") String brokerName,
+                                                           @RequestParam("org_name") Optional<String> orgName,
+                                                           @RequestParam("space_name") Optional<String> spaceName,
+                                                           @RequestParam("service_label") Optional<String> serviceLabel,
+                                                           @RequestParam("plan_name") Optional<String> planName,
+                                                           @RequestParam("instance_name") Optional<String> instanceName) {
         return serviceBindingsService.list(ImmutableListServiceBindingsRequest.builder()
                 .serviceBrokerName(brokerName)
                 .orgName(orgName)
@@ -57,7 +55,6 @@ public class ServiceBindingsController {
                 .servicePlanName(planName)
                 .serviceInstanceName(instanceName)
                 .build())
-                .collectList()
                 .block(Duration.ofMinutes(timeout));
     }
 
@@ -76,12 +73,12 @@ public class ServiceBindingsController {
      **/
     @PostMapping(value = "/v1/service_brokers/{brokerName}/service_bindings")
     @ResponseStatus(HttpStatus.CREATED)
-    public List<ServiceBindingDetail> rebindServiceBindings(@PathVariable("brokerName") String brokerName,
-                                                            @RequestParam("org_name") Optional<String> orgName,
-                                                            @RequestParam("space_name") Optional<String> spaceName,
-                                                            @RequestParam("service_label") Optional<String> serviceLabel,
-                                                            @RequestParam("plan_name") Optional<String> planName,
-                                                            @RequestParam("instance_name") Optional<String> instanceName) {
+    public RebindServiceBindingsResponse rebindServiceBindings(@PathVariable("brokerName") String brokerName,
+                                                               @RequestParam("org_name") Optional<String> orgName,
+                                                               @RequestParam("space_name") Optional<String> spaceName,
+                                                               @RequestParam("service_label") Optional<String> serviceLabel,
+                                                               @RequestParam("plan_name") Optional<String> planName,
+                                                               @RequestParam("instance_name") Optional<String> instanceName) {
         return serviceBindingsService.rebind(ImmutableRebindServiceBindingsRequest.builder()
                 .serviceBrokerName(brokerName)
                 .orgName(orgName)
@@ -90,7 +87,6 @@ public class ServiceBindingsController {
                 .servicePlanName(planName)
                 .serviceInstanceName(instanceName)
                 .build())
-                .collectList()
                 .block(Duration.ofMinutes(timeout));
     }
 

--- a/src/main/java/com/orange/ops/sbire/domain/AbstractServiceBindingDetailResource.java
+++ b/src/main/java/com/orange/ops/sbire/domain/AbstractServiceBindingDetailResource.java
@@ -1,0 +1,9 @@
+package com.orange.ops.sbire.domain;
+
+import org.cloudfoundry.client.v2.Resource;
+
+/**
+ * The core resource in Service Bindings
+ */
+public abstract class AbstractServiceBindingDetailResource extends Resource<ServiceBindingDetail> {
+}

--- a/src/main/java/com/orange/ops/sbire/domain/ListServiceBindingsRequest.java
+++ b/src/main/java/com/orange/ops/sbire/domain/ListServiceBindingsRequest.java
@@ -4,18 +4,41 @@ import org.immutables.value.Value;
 
 import java.util.Optional;
 
+/**
+ * Details of a request to list service bindings.
+ *
+ * @author Sebastien Bortolussi
+ */
 @Value.Immutable
 public abstract class ListServiceBindingsRequest {
 
+    /**
+     * The name of the service broker whose service bindings need to be listed.
+     */
     public abstract String getServiceBrokerName();
 
+    /**
+     * The organization name of service bindings that need to be listed.
+     */
     public abstract Optional<String> getOrgName();
 
+    /**
+     * The space name of service bindings that need to be listed.
+     */
     public abstract Optional<String> getSpaceName();
 
+    /**
+     * The service label of service bindings that need to be listed.
+     */
     public abstract Optional<String> getServiceLabel();
 
+    /**
+     * The service plan name of service bindings that need to be listed.
+     */
     public abstract Optional<String> getServicePlanName();
 
+    /**
+     * The service instance name of service bindings that need to be listed.
+     */
     public abstract Optional<String> getServiceInstanceName();
 }

--- a/src/main/java/com/orange/ops/sbire/domain/ListServiceBindingsResponse.java
+++ b/src/main/java/com/orange/ops/sbire/domain/ListServiceBindingsResponse.java
@@ -1,0 +1,14 @@
+package com.orange.ops.sbire.domain;
+
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.immutables.value.Value;
+
+/**
+ * Details of a response to a request to list service bindings.
+ *
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+public abstract class ListServiceBindingsResponse extends PaginatedResponse<ServiceBindingDetailResource> {
+
+}

--- a/src/main/java/com/orange/ops/sbire/domain/RebindServiceBindingsRequest.java
+++ b/src/main/java/com/orange/ops/sbire/domain/RebindServiceBindingsRequest.java
@@ -4,18 +4,41 @@ import org.immutables.value.Value;
 
 import java.util.Optional;
 
+/**
+ * Details of a request to rebind (delete and then re-create) existing service bindings.
+ *
+ * @author Sebastien Bortolussi
+ */
 @Value.Immutable
 public abstract class RebindServiceBindingsRequest {
 
+    /**
+     * The name of the service broker whose service bindings need to be rebound.
+     */
     public abstract String getServiceBrokerName();
 
+    /**
+     * The organization name of service bindings that need to be rebound.
+     */
     public abstract Optional<String> getOrgName();
 
+    /**
+     * The space name of service bindings that need to be rebound.
+     */
     public abstract Optional<String> getSpaceName();
 
+    /**
+     * The service label of service bindings that need to be rebound.
+     */
     public abstract Optional<String> getServiceLabel();
 
+    /**
+     * The service plan name of service bindings that need to be rebound.
+     */
     public abstract Optional<String> getServicePlanName();
 
+    /**
+     * The service instance name of service bindings that need to be rebound.
+     */
     public abstract Optional<String> getServiceInstanceName();
 }

--- a/src/main/java/com/orange/ops/sbire/domain/RebindServiceBindingsResponse.java
+++ b/src/main/java/com/orange/ops/sbire/domain/RebindServiceBindingsResponse.java
@@ -1,0 +1,14 @@
+package com.orange.ops.sbire.domain;
+
+import org.cloudfoundry.client.v2.PaginatedResponse;
+import org.immutables.value.Value;
+
+/**
+ * Details of a response to a request to rebind (delete and then re-create) existing service bindings.
+ *
+ * @author Sebastien Bortolussi
+ */
+@Value.Immutable
+public abstract class RebindServiceBindingsResponse extends PaginatedResponse<ServiceBindingDetailResource> {
+
+}

--- a/src/main/java/com/orange/ops/sbire/domain/ServiceBindingDetail.java
+++ b/src/main/java/com/orange/ops/sbire/domain/ServiceBindingDetail.java
@@ -3,27 +3,56 @@ package com.orange.ops.sbire.domain;
 import org.immutables.value.Value;
 
 /**
+ * Service binding details.
+ *
  * @author Sebastien Bortolussi
  */
 @Value.Immutable
 public abstract class ServiceBindingDetail {
 
+    /**
+     * The id of the service service binding.
+     */
     public abstract String getId();
 
+    /**
+     * The service instance id of the service service binding.
+     */
     public abstract String getServiceInstanceId();
 
+    /**
+     * The service instance name of the service service binding.
+     */
     public abstract String getServiceInstanceName();
 
+    /**
+     * The service application id of the service service binding.
+     */
     public abstract String getApplicationId();
 
+    /**
+     * The service application name of the service service binding.
+     */
     public abstract String getApplicationName();
 
+    /**
+     * The service plan name of the service service binding.
+     */
     public abstract String getServicePlan();
 
+    /**
+     * The service name of the service service binding.
+     */
     public abstract String getService();
 
+    /**
+     * The space name of the service service binding.
+     */
     public abstract String getSpace();
 
+    /**
+     * The organization name of the service service binding.
+     */
     public abstract String getOrganization();
 
 }

--- a/src/main/java/com/orange/ops/sbire/domain/ServiceBindingDetailResource.java
+++ b/src/main/java/com/orange/ops/sbire/domain/ServiceBindingDetailResource.java
@@ -1,0 +1,11 @@
+package com.orange.ops.sbire.domain;
+
+import org.immutables.value.Value;
+
+/**
+ * Service binding Resource in responses
+ */
+@Value.Immutable
+public abstract class ServiceBindingDetailResource extends AbstractServiceBindingDetailResource {
+
+}

--- a/src/main/java/com/orange/ops/sbire/domain/ServiceBindingsService.java
+++ b/src/main/java/com/orange/ops/sbire/domain/ServiceBindingsService.java
@@ -1,13 +1,48 @@
 package com.orange.ops.sbire.domain;
 
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
+ * This interface is implemented to process requests to list and rebind service bindings.
+ *
  * @author Sebastien Bortolussi
  */
+
 public interface ServiceBindingsService {
 
-    Flux<ServiceBindingDetail> list(ListServiceBindingsRequest request);
+    /**
+     * List service bindings for a service broker.
+     * Results can be filtered by :
+     * <ul>
+     * <li> org name</li>
+     * <li> space name</li>
+     * <li> service label</li>
+     * <li> plan name</li>
+     * <li> instance name</li>
+     * </ul>
+     * <p>
+     * See {@link ListServiceBindingsRequest} for details.
+     *
+     * @param request containing parameters sent from PaaS Operator
+     * @return a ListServiceBindingsResponse
+     */
+    Mono<ListServiceBindingsResponse> list(ListServiceBindingsRequest request);
 
-    Flux<ServiceBindingDetail> rebind(ImmutableRebindServiceBindingsRequest request);
+    /**
+     * Rebind (Delete and then Re-create) existing service bindings for a service broker.
+     * Rebind can be filtered by :
+     * <ul>
+     * <li> org name</li>
+     * <li> space name</li>
+     * <li> service label</li>
+     * <li> plan name</li>
+     * <li> instance name</li>
+     * </ul>
+     * <p>
+     * See {@link RebindServiceBindingsRequest} for details.
+     *
+     * @param request containing parameters sent from PaaS Operator
+     * @return a RebindServiceBindingsResponse
+     */
+    Mono<RebindServiceBindingsResponse> rebind(RebindServiceBindingsRequest request);
 }

--- a/src/test/java/com/orange/ops/sbire/controller/ListServiceBindingsControllerTest.java
+++ b/src/test/java/com/orange/ops/sbire/controller/ListServiceBindingsControllerTest.java
@@ -31,7 +31,7 @@ public class ListServiceBindingsControllerTest extends SimpleSpringScenarioTest<
                 .build());
         when().paas_ops_lists_service_broker_service_bindings("/v1/service_brokers/p-redis/service_bindings");
         then().she_should_get_HTTP_$_response(HttpStatus.OK)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
     }
 
     @Test
@@ -41,7 +41,7 @@ public class ListServiceBindingsControllerTest extends SimpleSpringScenarioTest<
                 .build());
         when().paas_ops_lists_service_broker_service_bindings("/v1/service_brokers/p-redis/service_bindings?org_name=org1");
         then().she_should_get_HTTP_$_response(HttpStatus.OK)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"org1\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"org1\"}}]");
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ListServiceBindingsControllerTest extends SimpleSpringScenarioTest<
                 .build());
         when().paas_ops_lists_service_broker_service_bindings("/v1/service_brokers/p-redis/service_bindings?org_name=org1&space_name=space12");
         then().she_should_get_HTTP_$_response(HttpStatus.OK)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"space12\",\"organization\": \"org1\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"space12\",\"organization\": \"org1\"}}]");
 
     }
 
@@ -63,7 +63,7 @@ public class ListServiceBindingsControllerTest extends SimpleSpringScenarioTest<
                 .build());
         when().paas_ops_lists_service_broker_service_bindings("/v1/service_brokers/p-redis/service_bindings?service_label=p-redis");
         then().she_should_get_HTTP_$_response(HttpStatus.OK)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"p-redis\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"p-redis\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
     }
 
     @Test
@@ -73,7 +73,7 @@ public class ListServiceBindingsControllerTest extends SimpleSpringScenarioTest<
                 .build());
         when().paas_ops_lists_service_broker_service_bindings("/v1/service_brokers/p-redis/service_bindings?plan_name=dedicated-vm");
         then().she_should_get_HTTP_$_response(HttpStatus.OK)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"dedicated-vm\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"dedicated-vm\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
 
     }
 
@@ -84,7 +84,7 @@ public class ListServiceBindingsControllerTest extends SimpleSpringScenarioTest<
                 .build());
         when().paas_ops_lists_service_broker_service_bindings("/v1/service_brokers/p-redis/service_bindings?instance_name=my-redis-112");
         then().she_should_get_HTTP_$_response(HttpStatus.OK)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"my-redis-112\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"my-redis-112\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
     }
 
 }

--- a/src/test/java/com/orange/ops/sbire/controller/RebindServiceBindingsControllerStage.java
+++ b/src/test/java/com/orange/ops/sbire/controller/RebindServiceBindingsControllerStage.java
@@ -1,11 +1,10 @@
 package com.orange.ops.sbire.controller;
 
-import com.orange.ops.sbire.domain.ImmutableRebindServiceBindingsRequest;
-import com.orange.ops.sbire.domain.ImmutableServiceBindingDetail;
-import com.orange.ops.sbire.domain.ServiceBindingsService;
+import com.orange.ops.sbire.domain.*;
 import com.tngtech.jgiven.Stage;
 import com.tngtech.jgiven.annotation.Table;
 import com.tngtech.jgiven.integration.spring.JGivenStage;
+import org.cloudfoundry.client.v2.Metadata;
 import org.mockito.Answers;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +13,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.util.stream.Stream;
+
+import static org.cloudfoundry.util.test.TestObjects.fill;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,11 +36,28 @@ public class RebindServiceBindingsControllerStage extends Stage<RebindServiceBin
 
     private ResultActions perform;
 
+    private static ImmutableRebindServiceBindingsResponse toRebindServiceBindingsResponse(ImmutableServiceBindingDetail... serviceBindings) {
+
+        final ImmutableRebindServiceBindingsResponse.Builder responseBuilder = fill(ImmutableRebindServiceBindingsResponse.builder());
+
+        Stream.of(serviceBindings)
+                .map(serviceBinding -> ImmutableServiceBindingDetailResource.builder()
+                        .metadata(fill(Metadata.builder())
+                                .id(serviceBinding.getId())
+                                .build())
+                        .entity(fill(ImmutableServiceBindingDetail.builder()).build())
+                        .build()
+                )
+                .forEach(responseBuilder::addResources);
+
+        return responseBuilder.totalResults(1).build();
+    }
+
     public RebindServiceBindingsControllerStage service_broker_service_bindings(@Table ImmutableServiceBindingDetail... serviceBindings) {
         BDDMockito.given(this.serviceBindingsService.rebind(ImmutableRebindServiceBindingsRequest.builder()
                 .serviceBrokerName("p-redis")
                 .build()))
-                .willReturn(Flux.just(serviceBindings));
+                .willReturn(Mono.just(toRebindServiceBindingsResponse(serviceBindings)));
         return self();
     }
 
@@ -47,7 +66,7 @@ public class RebindServiceBindingsControllerStage extends Stage<RebindServiceBin
                 .serviceBrokerName("p-redis")
                 .orgName("org1")
                 .build()))
-                .willReturn(Flux.just(serviceBindings));
+                .willReturn(Mono.just(toRebindServiceBindingsResponse(serviceBindings)));
         return self();
     }
 
@@ -57,7 +76,7 @@ public class RebindServiceBindingsControllerStage extends Stage<RebindServiceBin
                 .orgName("org1")
                 .spaceName("space12")
                 .build()))
-                .willReturn(Flux.just(serviceBindings));
+                .willReturn(Mono.just(toRebindServiceBindingsResponse(serviceBindings)));
         return self();
     }
 
@@ -66,7 +85,7 @@ public class RebindServiceBindingsControllerStage extends Stage<RebindServiceBin
                 .serviceBrokerName("p-redis")
                 .serviceLabel("p-redis")
                 .build()))
-                .willReturn(Flux.just(serviceBindings));
+                .willReturn(Mono.just(toRebindServiceBindingsResponse(serviceBindings)));
         return self();
     }
 
@@ -75,7 +94,7 @@ public class RebindServiceBindingsControllerStage extends Stage<RebindServiceBin
                 .serviceBrokerName("p-redis")
                 .servicePlanName("dedicated-vm")
                 .build()))
-                .willReturn(Flux.just(serviceBindings));
+                .willReturn(Mono.just(toRebindServiceBindingsResponse(serviceBindings)));
         return self();
     }
 
@@ -84,7 +103,7 @@ public class RebindServiceBindingsControllerStage extends Stage<RebindServiceBin
                 .serviceBrokerName("p-redis")
                 .serviceInstanceName("my-redis-112")
                 .build()))
-                .willReturn(Flux.just(serviceBindings));
+                .willReturn(Mono.just(toRebindServiceBindingsResponse(serviceBindings)));
         return self();
     }
 

--- a/src/test/java/com/orange/ops/sbire/controller/RebindServiceBindingsControllerTest.java
+++ b/src/test/java/com/orange/ops/sbire/controller/RebindServiceBindingsControllerTest.java
@@ -31,7 +31,7 @@ public class RebindServiceBindingsControllerTest extends SimpleSpringScenarioTes
                 .build());
         when().paas_ops_POST_$_to_rebind_service_bindings("/v1/service_brokers/p-redis/service_bindings");
         then().she_should_get_HTTP_$_response(HttpStatus.CREATED)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
     }
 
     @Test
@@ -41,7 +41,7 @@ public class RebindServiceBindingsControllerTest extends SimpleSpringScenarioTes
                 .build());
         when().paas_ops_POST_$_to_rebind_service_bindings("/v1/service_brokers/p-redis/service_bindings?org_name=org1");
         then().she_should_get_HTTP_$_response(HttpStatus.CREATED)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"org1\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"org1\"}}]");
     }
 
     @Test
@@ -52,7 +52,7 @@ public class RebindServiceBindingsControllerTest extends SimpleSpringScenarioTes
                 .build());
         when().paas_ops_POST_$_to_rebind_service_bindings("/v1/service_brokers/p-redis/service_bindings?org_name=org1&space_name=space12");
         then().she_should_get_HTTP_$_response(HttpStatus.CREATED)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"space12\",\"organization\": \"org1\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"space12\",\"organization\": \"org1\"}}]");
 
     }
 
@@ -63,7 +63,7 @@ public class RebindServiceBindingsControllerTest extends SimpleSpringScenarioTes
                 .build());
         when().paas_ops_POST_$_to_rebind_service_bindings("/v1/service_brokers/p-redis/service_bindings?service_label=p-redis");
         then().she_should_get_HTTP_$_response(HttpStatus.CREATED)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"p-redis\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"p-redis\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
     }
 
     @Test
@@ -73,7 +73,7 @@ public class RebindServiceBindingsControllerTest extends SimpleSpringScenarioTes
                 .build());
         when().paas_ops_POST_$_to_rebind_service_bindings("/v1/service_brokers/p-redis/service_bindings?plan_name=dedicated-vm");
         then().she_should_get_HTTP_$_response(HttpStatus.CREATED)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"dedicated-vm\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"test-serviceInstanceName\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"dedicated-vm\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
 
     }
 
@@ -84,7 +84,7 @@ public class RebindServiceBindingsControllerTest extends SimpleSpringScenarioTes
                 .build());
         when().paas_ops_POST_$_to_rebind_service_bindings("/v1/service_brokers/p-redis/service_bindings?instance_name=my-redis-112");
         then().she_should_get_HTTP_$_response(HttpStatus.CREATED)
-                .she_should_get_json_response("[{\"id\": \"test-id\",\"serviceInstanceName\": \"my-redis-112\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}]");
+                .she_should_get_json_response("{\"next_url\":\"test-nextUrl\",\"prev_url\":\"test-previousUrl\",\"total_pages\":1,\"total_results\":1}\"resources\":[{\"entity\":{\"id\": \"test-id\",\"serviceInstanceName\": \"my-redis-112\",\"applicationName\": \"test-applicationName\",\"servicePlan\": \"test-servicePlan\",\"service\": \"test-service\",\"space\": \"test-space\",\"organization\": \"test-organization\"}}]");
     }
 
 }

--- a/src/test/java/com/orange/ops/sbire/domain/DefaultServiceBindingsServiceIT.java
+++ b/src/test/java/com/orange/ops/sbire/domain/DefaultServiceBindingsServiceIT.java
@@ -36,8 +36,6 @@ public class DefaultServiceBindingsServiceIT {
                 .serviceBrokerName(SERVICE_BROKER_NAME)
                 .build())
                 .doOnNext(System.out::println)
-                .count()
-                .doOnNext(System.out::println)
                 .then()
                 .block(Duration.ofMinutes(5L));
     }
@@ -50,8 +48,6 @@ public class DefaultServiceBindingsServiceIT {
                 .orgName(testOrgName)
                 .build())
                 .doOnNext(System.out::println)
-                .count()
-                .doOnNext(System.out::println)
                 .block(Duration.ofMinutes(5));
     }
 
@@ -63,8 +59,6 @@ public class DefaultServiceBindingsServiceIT {
                 .orgName(testOrgName)
                 .spaceName(testSpace)
                 .build())
-                .doOnNext(System.out::println)
-                .count()
                 .doOnNext(System.out::println)
                 .block(Duration.ofMinutes(5));
     }

--- a/src/test/java/com/orange/ops/sbire/domain/ListServiceBindingsTest.java
+++ b/src/test/java/com/orange/ops/sbire/domain/ListServiceBindingsTest.java
@@ -62,7 +62,7 @@ public class ListServiceBindingsTest extends SimpleScenarioTest<ServiceBindingsS
     public void paas_ops_lists_all_service_broker_service_bindings() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_lists_service_broker_$_service_bindings("p-redis");
-        then().she_should_get_service_bindings(ALL_SERVICE_BINDINGS);
+        then().she_should_get_$_service_bindings(4, ALL_SERVICE_BINDINGS);
     }
 
     @Test
@@ -76,31 +76,30 @@ public class ListServiceBindingsTest extends SimpleScenarioTest<ServiceBindingsS
     public void paas_ops_lists_service_broker_service_bindings_for_an_org() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_lists_service_broker_$_service_bindings_for_org("p-redis", "org1");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("aaa")
-                                .serviceInstanceId("my-redis-111-id")
-                                .serviceInstanceName("my-redis-111")
-                                .servicePlan("shared-vm")
-                                .service("p-redis")
-                                .space("space11")
-                                .organization("org1")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build(),
-                        ImmutableServiceBindingDetail.builder()
-                                .id("bbb")
-                                .serviceInstanceId("my-redis-211-id")
-                                .serviceInstanceName("my-redis-211")
-                                .servicePlan("dedicated-vm")
-                                .service("p-redis")
-                                .space("space11")
-                                .organization("org1")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_service_bindings(2,
+                ImmutableServiceBindingDetail.builder()
+                        .id("aaa")
+                        .serviceInstanceId("my-redis-111-id")
+                        .serviceInstanceName("my-redis-111")
+                        .servicePlan("shared-vm")
+                        .service("p-redis")
+                        .space("space11")
+                        .organization("org1")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build(),
+                ImmutableServiceBindingDetail.builder()
+                        .id("bbb")
+                        .serviceInstanceId("my-redis-211-id")
+                        .serviceInstanceName("my-redis-211")
+                        .servicePlan("dedicated-vm")
+                        .service("p-redis")
+                        .space("space11")
+                        .organization("org1")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
@@ -114,20 +113,19 @@ public class ListServiceBindingsTest extends SimpleScenarioTest<ServiceBindingsS
     public void paas_ops_lists_service_broker_service_bindings_for_a_space() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_lists_service_broker_$_service_bindings_for_org_$_and_space("p-redis", "org2", "space12");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("ccc")
-                                .serviceInstanceId("my-redis-112-id")
-                                .serviceInstanceName("my-redis-112")
-                                .servicePlan("shared-vm")
-                                .service("p-redis")
-                                .space("space12")
-                                .organization("org2")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_service_bindings(1,
+                ImmutableServiceBindingDetail.builder()
+                        .id("ccc")
+                        .serviceInstanceId("my-redis-112-id")
+                        .serviceInstanceName("my-redis-112")
+                        .servicePlan("shared-vm")
+                        .service("p-redis")
+                        .space("space12")
+                        .organization("org2")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
@@ -141,7 +139,7 @@ public class ListServiceBindingsTest extends SimpleScenarioTest<ServiceBindingsS
     public void paas_ops_lists_service_broker_service_bindings_for_a_service_label() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_lists_service_broker_$_service_bindings_for_service_label("p-redis", "p-redis");
-        then().she_should_get_service_bindings(ALL_SERVICE_BINDINGS);
+        then().she_should_get_$_service_bindings(4, ALL_SERVICE_BINDINGS);
     }
 
     @Test
@@ -156,20 +154,19 @@ public class ListServiceBindingsTest extends SimpleScenarioTest<ServiceBindingsS
     public void paas_ops_lists_service_broker_service_bindings_for_a_service_plan() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_lists_service_broker_$_service_bindings_for_service_plan_name("p-redis", "dedicated-vm");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("bbb")
-                                .serviceInstanceId("my-redis-211-id")
-                                .serviceInstanceName("my-redis-211")
-                                .servicePlan("dedicated-vm")
-                                .service("p-redis")
-                                .space("space11")
-                                .organization("org1")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_service_bindings(1,
+                ImmutableServiceBindingDetail.builder()
+                        .id("bbb")
+                        .serviceInstanceId("my-redis-211-id")
+                        .serviceInstanceName("my-redis-211")
+                        .servicePlan("dedicated-vm")
+                        .service("p-redis")
+                        .space("space11")
+                        .organization("org1")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
@@ -183,20 +180,19 @@ public class ListServiceBindingsTest extends SimpleScenarioTest<ServiceBindingsS
     public void paas_ops_lists_service_broker_service_bindings_for_a_service_instance() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_lists_service_broker_$_service_bindings_for_service_instance("p-redis", "my-redis-112");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("ccc")
-                                .serviceInstanceId("my-redis-112-id")
-                                .serviceInstanceName("my-redis-112")
-                                .servicePlan("shared-vm")
-                                .service("p-redis")
-                                .space("space12")
-                                .organization("org2")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_service_bindings(1,
+                ImmutableServiceBindingDetail.builder()
+                        .id("ccc")
+                        .serviceInstanceId("my-redis-112-id")
+                        .serviceInstanceName("my-redis-112")
+                        .servicePlan("shared-vm")
+                        .service("p-redis")
+                        .space("space12")
+                        .organization("org2")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test

--- a/src/test/java/com/orange/ops/sbire/domain/RebindServiceBindingsTest.java
+++ b/src/test/java/com/orange/ops/sbire/domain/RebindServiceBindingsTest.java
@@ -61,7 +61,8 @@ public class RebindServiceBindingsTest extends SimpleScenarioTest<ServiceBinding
     public void paas_ops_rebinds_all_service_broker_service_bindings() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings("p-redis");
-        then().she_should_get_service_bindings(ImmutableServiceBindingDetail.builder()
+        then().she_should_get_$_new_service_bindings(4,
+                ImmutableServiceBindingDetail.builder()
                         .id("eee")
                         .serviceInstanceId("my-redis-111-id")
                         .serviceInstanceName("my-redis-111")
@@ -111,79 +112,78 @@ public class RebindServiceBindingsTest extends SimpleScenarioTest<ServiceBinding
     public void paas_ops_rebinds_service_bindings_for_unknown_service_broker() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings("dummy");
-        then().she_should_get_error("Service Broker dummy does not exist");
+        then().she_should_get_a_rebind_error("Service Broker dummy does not exist");
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_an_org() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_org("p-redis", "org1");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("eee")
-                                .serviceInstanceId("my-redis-111-id")
-                                .serviceInstanceName("my-redis-111")
-                                .servicePlan("shared-vm")
-                                .service("p-redis")
-                                .space("space11")
-                                .organization("org1")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build(),
-                        ImmutableServiceBindingDetail.builder()
-                                .id("fff")
-                                .serviceInstanceId("my-redis-211-id")
-                                .serviceInstanceName("my-redis-211")
-                                .servicePlan("dedicated-vm")
-                                .service("p-redis")
-                                .space("space11")
-                                .organization("org1")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_new_service_bindings(2,
+                ImmutableServiceBindingDetail.builder()
+                        .id("eee")
+                        .serviceInstanceId("my-redis-111-id")
+                        .serviceInstanceName("my-redis-111")
+                        .servicePlan("shared-vm")
+                        .service("p-redis")
+                        .space("space11")
+                        .organization("org1")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build(),
+                ImmutableServiceBindingDetail.builder()
+                        .id("fff")
+                        .serviceInstanceId("my-redis-211-id")
+                        .serviceInstanceName("my-redis-211")
+                        .servicePlan("dedicated-vm")
+                        .service("p-redis")
+                        .space("space11")
+                        .organization("org1")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_an_unknown_org() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_org("p-redis", "dummy");
-        then().she_should_get_no_service_binding();
+        then().she_should_get_no_service_binding_created();
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_a_space() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_org_$_and_space("p-redis", "org2", "space12");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("ggg")
-                                .serviceInstanceId("my-redis-112-id")
-                                .serviceInstanceName("my-redis-112")
-                                .servicePlan("shared-vm")
-                                .service("p-redis")
-                                .space("space12")
-                                .organization("org2")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_new_service_bindings(1,
+                ImmutableServiceBindingDetail.builder()
+                        .id("ggg")
+                        .serviceInstanceId("my-redis-112-id")
+                        .serviceInstanceName("my-redis-112")
+                        .servicePlan("shared-vm")
+                        .service("p-redis")
+                        .space("space12")
+                        .organization("org2")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_an_unknown_space() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_org_$_and_space("p-redis", "org2", "dummy");
-        then().she_should_get_no_service_binding();
+        then().she_should_get_no_service_binding_created();
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_a_service_label() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_service_label("p-redis", "p-redis");
-        then().she_should_get_service_bindings(ImmutableServiceBindingDetail.builder()
+        then().she_should_get_$_new_service_bindings(4,
+                ImmutableServiceBindingDetail.builder()
                         .id("eee")
                         .serviceInstanceId("my-redis-111-id")
                         .serviceInstanceName("my-redis-111")
@@ -233,7 +233,7 @@ public class RebindServiceBindingsTest extends SimpleScenarioTest<ServiceBinding
     public void paas_ops_rebinds_service_broker_service_bindings_for_an_unknown_service_label() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_service_label("p-redis", "dummy");
-        then().she_should_get_no_service_binding();
+        then().she_should_get_no_service_binding_created();
     }
 
 
@@ -241,54 +241,52 @@ public class RebindServiceBindingsTest extends SimpleScenarioTest<ServiceBinding
     public void paas_ops_rebinds_service_broker_service_bindings_for_a_service_plan() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_service_plan_name("p-redis", "dedicated-vm");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("fff")
-                                .serviceInstanceId("my-redis-211-id")
-                                .serviceInstanceName("my-redis-211")
-                                .servicePlan("dedicated-vm")
-                                .service("p-redis")
-                                .space("space11")
-                                .organization("org1")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_new_service_bindings(1,
+                ImmutableServiceBindingDetail.builder()
+                        .id("fff")
+                        .serviceInstanceId("my-redis-211-id")
+                        .serviceInstanceName("my-redis-211")
+                        .servicePlan("dedicated-vm")
+                        .service("p-redis")
+                        .space("space11")
+                        .organization("org1")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_an_unknown_service_plan() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_service_plan_name("p-redis", "dummy");
-        then().she_should_get_no_service_binding();
+        then().she_should_get_no_service_binding_created();
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_a_service_instance() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_service_instance("p-redis", "my-redis-112");
-        then().she_should_get_service_bindings
-                (
-                        ImmutableServiceBindingDetail.builder()
-                                .id("ggg")
-                                .serviceInstanceId("my-redis-112-id")
-                                .serviceInstanceName("my-redis-112")
-                                .servicePlan("shared-vm")
-                                .service("p-redis")
-                                .space("space12")
-                                .organization("org2")
-                                .applicationId("my-app-id")
-                                .applicationName("my-app")
-                                .build()
-                );
+        then().she_should_get_$_new_service_bindings(1,
+                ImmutableServiceBindingDetail.builder()
+                        .id("ggg")
+                        .serviceInstanceId("my-redis-112-id")
+                        .serviceInstanceName("my-redis-112")
+                        .servicePlan("shared-vm")
+                        .service("p-redis")
+                        .space("space12")
+                        .organization("org2")
+                        .applicationId("my-app-id")
+                        .applicationName("my-app")
+                        .build()
+        );
     }
 
     @Test
     public void paas_ops_rebinds_service_broker_service_bindings_for_an_unknown_service_instance() throws Exception {
         given().service_bindings(ALL_SERVICE_BINDINGS);
         when().paas_ops_rebinds_service_broker_$_service_bindings_for_service_instance("p-redis", "dummy");
-        then().she_should_get_no_service_binding();
+        then().she_should_get_no_service_binding_created();
     }
 
 }


### PR DESCRIPTION
This change adds feature to return a total of results in `list service bindings (GET /v1/service_brokers/{broker_name}/service_bindings)` and `rebind service bindings (POST /v1/service_brokers/{broker_name}/service_bindings)` responses.

[#5]